### PR TITLE
fix: remove modernize-use-nullptr flag for C++98 compatibility

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -46,4 +46,5 @@ Diagnostics:
         modernize-use-trailing-return-type,
         modernize-use-nodiscard,
         modernize-avoid-c-arrays,
+        modernize-use-nullptr,
       ]

--- a/.github/auto_assign_config.yml
+++ b/.github/auto_assign_config.yml
@@ -10,5 +10,5 @@ numberOfReviewers: 0
 
 assignees:
   - author
-  - Jonathan52
+  - Jonathan523
 numberOfAssignees: 0


### PR DESCRIPTION
Remove modernize-use-nullptr flag for C++98 compatibility